### PR TITLE
Resolve compliation issues on linux (case-sensitive includes)

### DIFF
--- a/ReroShaders/ReroStandard/Shaders/CGINC/UnityStandardCoreRero.cginc
+++ b/ReroShaders/ReroStandard/Shaders/CGINC/UnityStandardCoreRero.cginc
@@ -12,7 +12,7 @@
 #include "UnityStandardUtilsRero.cginc"
 #include "UnityGBuffer.cginc"
 //#include "UnityStandardBRDF.cginc"
-#include "UnityStandardBRDFcustom.cginc"
+#include "UnityStandardBRDFCustom.cginc"
 #define UNITY_BRDF_PBS BRDF_Unity_Rero
 #include "AutoLight.cginc"
 //-------------------------------------------------------------------------------------


### PR DESCRIPTION
Shader paths apparently need to be in the correct case to compile in the unity editor on Linux. Unfortunately when the material is on a character they turn invisible in the editor, but it displays properly once uploaded to VRChat.